### PR TITLE
Support custom region

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,20 @@ parameter|sceptre_user_data:
 parameter|sceptre_user_data:
   <name>: !ssm
     name: /prefix/param
+    region: us-east-1
     profile: OtherAccount
 ```
 
 ```yaml
 parameter|sceptre_user_data:
-  <name>: !ssm {"name": "/prefix/param", "profile": "OtherAccount"}
+  <name>: !ssm {"name": "/prefix/param", "region": "us-east-1", "profile": "OtherAccount"}
 ```
 
+
+#### Parameters
+* name - SSM key name, mandatory
+* region - SSM key region, optional, stack region by default
+* profile - SSM key's account profile , optional, stack profile by default
 
 #### Example:
 


### PR DESCRIPTION
In some cases you want to store a secret in a single region and then pass it to all you stacks in other regions.

My use case -- the same token for Kinesis across 17 regions is stored in a single region (to be keep it maintainable) and passed as a parameter to all stack in all 17 regions